### PR TITLE
remove inquirer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "babel-tape-runner": "2.0.1",
     "eslint": "4.17.0",
     "greenkeeper-lockfile": "1.13.2",
-    "inquirer": "5.0.1",
     "istanbul": "1.1.0-alpha.1",
     "rollup": "0.55.1",
     "rollup-plugin-spl": "0.0.5",


### PR DESCRIPTION
After switching to rollup-plugin-spl, inquirer is no longer required as a direct dependency.

<!-- these actions are mandatory: -->
- [X] manually tested changes with target/ktapi-full.js
